### PR TITLE
Fix #18518: Add support for ngrok’s `X-Original-Host` header

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Framework 2 Change Log
 - Enh #18487: Allow creating URLs for non-GET-verb rules (bizley)
 - Bug #8750: Fix MySQL support when running in `ANSI`/`ANSI_QUOTES` modes (brandonkelly)
 - Bug #18505: Fixed `yii\helpers\ArrayHelper::getValue()` for ArrayAccess objects with explicitly defined properties (samdark)
+- Enh #18518: Add support for ngrok’s `X-Original-Host` header (brandonkelly)
 
 
 2.0.40 December 23, 2020

--- a/framework/web/Request.php
+++ b/framework/web/Request.php
@@ -231,6 +231,9 @@ class Request extends \yii\base\Request
         // Microsoft:
         'Front-End-Https',
         'X-Rewrite-Url',
+
+        // ngrok:
+        'X-Original-Host',
     ];
     /**
      * @var string[] List of headers where proxies store the real client IP.
@@ -744,6 +747,8 @@ class Request extends \yii\base\Request
                 $this->_hostInfo = $http . '://' . $this->getSecureForwardedHeaderTrustedPart('host');
             } elseif ($this->headers->has('X-Forwarded-Host')) {
                 $this->_hostInfo = $http . '://' . trim(explode(',', $this->headers->get('X-Forwarded-Host'))[0]);
+            } elseif ($this->headers->has('X-Original-Host')) {
+                $this->_hostInfo = $http . '://' . trim(explode(',', $this->headers->get('X-Original-Host'))[0]);
             } elseif ($this->headers->has('Host')) {
                 $this->_hostInfo = $http . '://' . $this->headers->get('Host');
             } elseif (isset($_SERVER['SERVER_NAME'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
