### PR TITLE
Fix #14343: Fix `yii\test\ActiveFixture` to use model's DB connection…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 Change Log
 - Bug #17174: Fix `yii\db\BaseActiveRecord::unlink()` to not ignore `on` conditions in `via` relations (bizley)
 - Bug #18557: Fix `yii\data\ActiveDataProvider` to handle DB connection configuration of different type than just `yii\db\Connection` (bizley)
 - Bug #18526: Fix `yii\caching\DbCache` to work with MSSQL, add `normalizeTableRowData()` to `yii\db\mssql\QueryBuilder::upsert()` (darkdef)
+- Bug #14343: Fix `yii\test\ActiveFixture` to use model's DB connection instead of the default one (margori, bizley)
 
 
 2.0.41.1 March 04, 2021

--- a/framework/test/ActiveFixture.php
+++ b/framework/test/ActiveFixture.php
@@ -8,6 +8,7 @@
 namespace yii\test;
 
 use yii\base\InvalidConfigException;
+use yii\db\ActiveRecord;
 use yii\db\TableSchema;
 
 /**
@@ -58,8 +59,13 @@ class ActiveFixture extends BaseActiveFixture
     public function init()
     {
         parent::init();
-        if ($this->modelClass === null && $this->tableName === null) {
-            throw new InvalidConfigException('Either "modelClass" or "tableName" must be set.');
+        if ($this->tableName === null) {
+            if ($this->modelClass === null) {
+                throw new InvalidConfigException('Either "modelClass" or "tableName" must be set.');
+            }
+            /** @var ActiveRecord $modelClass */
+            $modelClass = $this->modelClass;
+            $this->db = $modelClass::getDb();
         }
     }
 

--- a/tests/framework/console/controllers/FixtureControllerTest.php
+++ b/tests/framework/console/controllers/FixtureControllerTest.php
@@ -9,10 +9,9 @@ namespace yiiunit\framework\console\controllers;
 
 use Yii;
 use yii\console\controllers\FixtureController;
+use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\console\controllers\fixtures\DependentActiveFixture;
-use yiiunit\data\console\controllers\fixtures\FirstIndependentActiveFixture;
 use yiiunit\data\console\controllers\fixtures\FixtureStorage;
-use yiiunit\data\console\controllers\fixtures\SecondIndependentActiveFixture;
 use yiiunit\framework\db\DatabaseTestCase;
 
 /**
@@ -37,6 +36,7 @@ class FixtureControllerTest extends DatabaseTestCase
 
         $db = $this->getConnection();
         \Yii::$app->set('db', $db);
+        ActiveRecord::$db = $db;
 
         $this->_fixtureController = Yii::createObject([
             'class' => 'yiiunit\framework\console\controllers\FixtureConsoledController',

--- a/tests/framework/test/ActiveFixtureTest.php
+++ b/tests/framework/test/ActiveFixtureTest.php
@@ -7,137 +7,13 @@
 
 namespace yiiunit\framework\test;
 
+use Yii;
+use yii\db\Connection;
 use yii\test\ActiveFixture;
 use yii\test\FixtureTrait;
 use yiiunit\data\ar\ActiveRecord;
 use yiiunit\data\ar\Customer;
 use yiiunit\framework\db\DatabaseTestCase;
-
-class ProfileFixture extends ActiveFixture
-{
-    public $modelClass = 'yiiunit\data\ar\Profile';
-
-    public function beforeLoad()
-    {
-        if ($this->db->driverName === 'sqlsrv') {
-            $this->db->createCommand()->truncateTable('profile')->execute();
-        }
-
-        parent::beforeLoad();
-    }
-
-    protected function getData()
-    {
-        $data = parent::getData();
-
-        if ($this->db->driverName === 'sqlsrv') {
-            array_walk($data, static function (&$item) {
-                unset($item['id']);
-            });
-        }
-
-        return $data;
-    }
-}
-
-class CustomerFixture extends ActiveFixture
-{
-    public $modelClass = 'yiiunit\data\ar\Customer';
-
-    public $depends = [
-        'yiiunit\framework\test\ProfileFixture',
-    ];
-
-    public function beforeLoad()
-    {
-        if ($this->db->driverName === 'sqlsrv') {
-            $this->db->createCommand()->truncateTable('customer')->execute();
-        }
-
-        parent::beforeLoad();
-    }
-}
-
-class CustomDirectoryFixture extends ActiveFixture
-{
-    public $modelClass = 'yiiunit\data\ar\Customer';
-
-    public $dataDirectory = '@app/framework/test/custom';
-
-    public function beforeLoad()
-    {
-        if ($this->db->driverName === 'sqlsrv') {
-            $this->db->createCommand()->truncateTable('customer')->execute();
-        }
-
-        parent::beforeLoad();
-    }
-}
-
-class AnimalFixture extends ActiveFixture
-{
-    public $modelClass = 'yiiunit\data\ar\Animal';
-}
-
-class BaseDbTestCase
-{
-    use FixtureTrait;
-
-    public function setUp()
-    {
-        $this->initFixtures();
-    }
-
-    public function tearDown()
-    {
-    }
-}
-
-class CustomerDbTestCase extends BaseDbTestCase
-{
-    public function fixtures()
-    {
-        return [
-            'customers' => CustomerFixture::className(),
-        ];
-    }
-}
-
-class CustomDirectoryDbTestCase extends BaseDbTestCase
-{
-    public function fixtures()
-    {
-        return [
-            'customers' => CustomDirectoryFixture::className(),
-        ];
-    }
-}
-
-class DataPathDbTestCase extends BaseDbTestCase
-{
-    public function fixtures()
-    {
-        return [
-            'customers' => [
-                'class' => CustomDirectoryFixture::className(),
-                'dataFile' => '@app/framework/test/data/customer.php'
-            ]
-        ];
-    }
-}
-
-class TruncateTestCase extends BaseDbTestCase
-{
-    public function fixtures()
-    {
-        return [
-            'animals' => [
-                'class' => AnimalFixture::className(),
-            ]
-        ];
-    }
-}
-
 
 /**
  * @group fixture
@@ -151,7 +27,7 @@ class ActiveFixtureTest extends DatabaseTestCase
     {
         parent::setUp();
         $db = $this->getConnection();
-        \Yii::$app->set('db', $db);
+        Yii::$app->set('db', $db);
         ActiveRecord::$db = $db;
     }
 
@@ -232,5 +108,154 @@ class ActiveFixtureTest extends DatabaseTestCase
         $fixture = $test->getFixture('animals');
         $this->assertEmpty($fixture->data);
         $test->tearDown();
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2/pull/14343
+     */
+    public function testDifferentModelDb()
+    {
+        $fixture = new DifferentDbFixture();
+
+        $this->assertSame('unique-dsn', $fixture->db->dsn);
+        $this->assertNotSame('unique-dsn', Yii::$app->getDb()->dsn);
+    }
+}
+
+class ProfileFixture extends ActiveFixture
+{
+    public $modelClass = 'yiiunit\data\ar\Profile';
+
+    public function beforeLoad()
+    {
+        if ($this->db->driverName === 'sqlsrv') {
+            $this->db->createCommand()->truncateTable('profile')->execute();
+        }
+
+        parent::beforeLoad();
+    }
+
+    protected function getData()
+    {
+        $data = parent::getData();
+
+        if ($this->db->driverName === 'sqlsrv') {
+            array_walk($data, static function (&$item) {
+                unset($item['id']);
+            });
+        }
+
+        return $data;
+    }
+}
+
+class CustomerFixture extends ActiveFixture
+{
+    public $modelClass = 'yiiunit\data\ar\Customer';
+
+    public $depends = [
+        'yiiunit\framework\test\ProfileFixture',
+    ];
+
+    public function beforeLoad()
+    {
+        if ($this->db->driverName === 'sqlsrv') {
+            $this->db->createCommand()->truncateTable('customer')->execute();
+        }
+
+        parent::beforeLoad();
+    }
+}
+
+class CustomDirectoryFixture extends ActiveFixture
+{
+    public $modelClass = 'yiiunit\data\ar\Customer';
+
+    public $dataDirectory = '@app/framework/test/custom';
+
+    public function beforeLoad()
+    {
+        if ($this->db->driverName === 'sqlsrv') {
+            $this->db->createCommand()->truncateTable('customer')->execute();
+        }
+
+        parent::beforeLoad();
+    }
+}
+
+class AnimalFixture extends ActiveFixture
+{
+    public $modelClass = 'yiiunit\data\ar\Animal';
+}
+
+class DifferentDbFixture extends ActiveFixture
+{
+    public $modelClass = 'yiiunit\framework\test\CustomDb';
+}
+
+class CustomDb extends ActiveRecord
+{
+    public static function getDb()
+    {
+        return new Connection(['dsn' => 'unique-dsn']);
+    }
+}
+
+class BaseDbTestCase
+{
+    use FixtureTrait;
+
+    public function setUp()
+    {
+        $this->initFixtures();
+    }
+
+    public function tearDown()
+    {
+    }
+}
+
+class CustomerDbTestCase extends BaseDbTestCase
+{
+    public function fixtures()
+    {
+        return [
+            'customers' => CustomerFixture::className(),
+        ];
+    }
+}
+
+class CustomDirectoryDbTestCase extends BaseDbTestCase
+{
+    public function fixtures()
+    {
+        return [
+            'customers' => CustomDirectoryFixture::className(),
+        ];
+    }
+}
+
+class DataPathDbTestCase extends BaseDbTestCase
+{
+    public function fixtures()
+    {
+        return [
+            'customers' => [
+                'class' => CustomDirectoryFixture::className(),
+                'dataFile' => '@app/framework/test/data/customer.php'
+            ]
+        ];
+    }
+}
+
+class TruncateTestCase extends BaseDbTestCase
+{
+    public function fixtures()
+    {
+        return [
+            'animals' => [
+                'class' => AnimalFixture::className(),
+            ]
+        ];
     }
 }


### PR DESCRIPTION
… instead of the default one

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
